### PR TITLE
ci: migrate actions/upload-artifact v3 -> v4 (substantive; unique names + pattern downloads) - release workflow

### DIFF
--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -128,9 +128,9 @@ jobs:
 
       - run: bundle exec rake gem:native:${{ matrix.platform }}
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
-          name: pkg
+          name: pkg-${{ matrix.platform }}
           path: pkg/*.gem
 
   package-linux-musl-x86_64:
@@ -152,9 +152,9 @@ jobs:
         bundle install
         bundle exec rake gem:native:x86_64-linux-musl
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
-        name: pkg
+        name: pkg-x86_64-linux-musl
         path: pkg/*.gem
 
   package-linux-musl-aarch64:
@@ -183,9 +183,9 @@ jobs:
           bundle install
           bundle exec rake gem:native:aarch64-linux-musl
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
-        name: pkg
+        name: pkg-aarch64-linux-musl
         path: pkg/*.gem
 
 # ----- Test packages with native extensions -----
@@ -212,10 +212,11 @@ jobs:
         bundler: ${{ env.BUNDLER_VER }}
         bundler-cache: false
 
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
-        name: pkg
+        pattern: pkg-*
         path: pkg
+        merge-multiple: true
 
     - name: Install binary gem
       run: |
@@ -241,10 +242,11 @@ jobs:
     - run: git config --global --add safe.directory $(pwd)
     - uses: actions/checkout@v4
 
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
-        name: pkg
+        pattern: pkg-*
         path: pkg
+        merge-multiple: true
 
     - run: gem install bundler:${{ env.BUNDLER_VER }} --no-document
     - name: Install binary gem
@@ -276,10 +278,11 @@ jobs:
         bundler: ${{ env.BUNDLER_VER }}
         bundler-cache: false
 
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
-        name: pkg
+        pattern: pkg-*
         path: pkg
+        merge-multiple: true
 
     - run: gem install bundler:${{ env.BUNDLER_VER }} --no-document
     - name: Install gem
@@ -304,10 +307,11 @@ jobs:
     - run: git config --global --add safe.directory $(pwd)
     - uses: actions/checkout@v4
 
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
-        name: pkg
+        pattern: pkg-*
         path: pkg
+        merge-multiple: true
 
     - run: gem install bundler:${{ env.BUNDLER_VER }} --no-document
     - name: Install ruby gem
@@ -324,10 +328,11 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
-        name: pkg
+        pattern: pkg-*
         path: pkg
+        merge-multiple: true
 
     - uses: actions-mn/gem-release@main
       with:


### PR DESCRIPTION
@ronaldtse — this repo's release workflow needs this substantive fix to keep releasing. GitHub is hard-failing runs pinning `actions/upload-artifact@v3` per its [deprecation schedule](https://github.com/actions/upload-artifact#v3-deprecation) — "automatically failed because it uses a deprecated version". Without the migration in this PR, no further pngcheck-ruby releases will fire.

## Why this can't be a mechanical v3 → v4 bump

The workflow's 3 upload jobs (matrix `package-many` + fixed `package-linux-musl-x86_64` + `package-linux-musl-aarch64`) all uploaded under the same name `pkg`. `v3` merged same-name uploads into one artifact; `v4` treats artifacts as immutable and rejects same-name collisions. A mechanical bump would fail-red on the second upload of every release.

## The correct v4 pattern

Unique per-upload names + `pattern:` / `merge-multiple: true` downloads reproduce v3's merged-directory behavior:

- **3 uploads renamed**: `pkg-${{ matrix.platform }}` in `package-many` (7 platforms), `pkg-x86_64-linux-musl`, `pkg-aarch64-linux-musl`. All v4.
- **5 downloads** (`test-binary-many`, `test-binary-alpine`, `test-ruby-many`, `test-ruby-alpine`, `release`): `pattern: pkg-*` + `path: pkg` + `merge-multiple: true`, all v4. Downstream jobs see the same merged `pkg/` directory as before.

## Behavior preserved

Every downstream job continues to read the full set of built gems out of `pkg/*.gem`. The release step's `for gem in pkg/*.gem; do gem push -V $gem; done` iterates over the same files. Test jobs' `gem install -b pkg/pngcheck-...` still resolves.

🤖
