### PR TITLE
ci(release): add standard trusted-publishing release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,23 @@
+name: release
+
+on:
+  workflow_dispatch:
+    inputs:
+      next_version:
+        description: |
+          Next release version. Possible values: x.y.z, major, minor, patch or pre|rc|etc.
+          Also, you can pass 'skip' to skip 'git tag' and do 'gem push' for the current version
+        required: true
+        default: 'skip'
+
+# Least-privilege ceiling for the called rubygems-release.yml: its release job
+# needs contents:write (git tag push) and id-token:write (OIDC Trusted Publishing).
+permissions:
+  contents: write
+  id-token: write
+
+jobs:
+  release:
+    uses: metanorma/ci/.github/workflows/rubygems-release.yml@main
+    with:
+      next_version: ${{ github.event.inputs.next_version }}


### PR DESCRIPTION
## Summary
- Adds the standard metanorma release workflow (caller of `metanorma/ci rubygems-release.yml`) — the repo previously had no gem-release workflow of the standard shape.
- OIDC-only: no `rubygems-api-key` secret passed (both shared-workflow secrets are optional), so publishing authenticates via the gem's trusted publisher (`metanorma/pngcheck-ruby @ rubygems-release.yml`, configured on rubygems.org).
- The existing `release-tag.yml` (upstream `metanorma-v*` tag sync) and `test-and-release.yml` are untouched.

## Test plan
- [x] YAML parses.
- [ ] After merge: dispatch with `next_version=skip` — current version already published, so only the OIDC exchange is exercised.
